### PR TITLE
[Qt] Fix inverted logic of "Latin Names" checkbox

### DIFF
--- a/src/celestia/qt/qtpreferencesdialog.cpp
+++ b/src/celestia/qt/qtpreferencesdialog.cpp
@@ -457,6 +457,8 @@ void PreferencesDialog::on_boundariesCheck_stateChanged(int state)
 
 void PreferencesDialog::on_latinNamesCheck_stateChanged(int state)
 {
+    // "Latin Names" Checkbox has inverted meaning
+    state = state == Qt::Checked ? Qt::Unchecked : Qt::Checked;
     setLabelFlag(appCore, Renderer::I18nConstellationLabels, state);
 }
 


### PR DESCRIPTION
When "Latin Names" is checked I see localized names, when unchecked - Latin. But only when click on the checkbox, not on startup.